### PR TITLE
Avoid full-table scan when resolving manufacturers

### DIFF
--- a/src/OpenA3XX.Core/Repositories/Aircraft/IManufacturerRepository.cs
+++ b/src/OpenA3XX.Core/Repositories/Aircraft/IManufacturerRepository.cs
@@ -7,5 +7,12 @@ namespace OpenA3XX.Core.Repositories.Aircraft
     {
         IList<Manufacturer> GetAllManufacturers();
         Manufacturer Add(Manufacturer manufacturer);
+
+        /// <summary>
+        /// Finds a manufacturer by its name.
+        /// </summary>
+        /// <param name="name">The manufacturer name to search for.</param>
+        /// <returns>The manufacturer if found; otherwise, null.</returns>
+        Manufacturer GetByName(string name);
     }
 }

--- a/src/OpenA3XX.Core/Repositories/Aircraft/ManufacturerRepository.cs
+++ b/src/OpenA3XX.Core/Repositories/Aircraft/ManufacturerRepository.cs
@@ -44,5 +44,21 @@ namespace OpenA3XX.Core.Repositories.Aircraft
             Save();
             return result;
         }
+
+        /// <summary>
+        /// Retrieves a manufacturer by name using a case-insensitive comparison.
+        /// </summary>
+        /// <param name="name">Name of the manufacturer to retrieve.</param>
+        /// <returns>The matching manufacturer or null if not found.</returns>
+        public Manufacturer GetByName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return null;
+            }
+
+            return GetAll()
+                .FirstOrDefault(m => m.Name.Equals(name, System.StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/OpenA3XX.Core/Services/Aircraft/AircraftModelService.cs
+++ b/src/OpenA3XX.Core/Services/Aircraft/AircraftModelService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using AutoMapper;
 using Microsoft.Extensions.Logging;
 using OpenA3XX.Core.Dtos;
@@ -126,16 +125,20 @@ namespace OpenA3XX.Core.Services.Aircraft
 
         private Manufacturer FindOrCreateManufacturer(string manufacturerName)
         {
-            var manufacturers = _manufacturerRepository.GetAllManufacturers();
-            var manufacturer = manufacturers.FirstOrDefault(m => m.Name.Equals(manufacturerName, StringComparison.OrdinalIgnoreCase));
-            
+            if (string.IsNullOrWhiteSpace(manufacturerName))
+            {
+                throw new ArgumentException("Manufacturer name cannot be null or whitespace.", nameof(manufacturerName));
+            }
+
+            var manufacturer = _manufacturerRepository.GetByName(manufacturerName);
+
             if (manufacturer == null)
             {
                 _logger.LogInformation("Creating new manufacturer: {ManufacturerName}", manufacturerName);
                 manufacturer = new Manufacturer { Name = manufacturerName };
                 manufacturer = _manufacturerRepository.Add(manufacturer);
             }
-            
+
             return manufacturer;
         }
     }


### PR DESCRIPTION
## Summary
- add repository method to find a manufacturer by name
- use new lookup in aircraft service and validate manufacturer names

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68925853f66c8329a297a27d0e036029